### PR TITLE
locked python pillow package version at 2.8.0

### DIFF
--- a/chef/cocaine/recipes/default.rb
+++ b/chef/cocaine/recipes/default.rb
@@ -54,7 +54,9 @@ bash 'Creating cocaine app control objects' do
   EOH
 end
 
-python_pip 'pillow'
+python_pip 'pillow' do
+  version '2.8.0'
+end
 python_pip 'qrcode'
 
 bash 'Installing QR-code example' do


### PR DESCRIPTION
Starting with Pillow 3.0.0, libjpeg is required by default.
http://pillow.readthedocs.org/en/3.0.x/installation.html